### PR TITLE
Added a homepage link to getbootstrap.com

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,7 +12,7 @@
           <script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>
         </div>
         <h1><a href="http://expo.getbootstrap.com">Bootstrap Expo</a></h1>
-        <span class="tagline">Beautiful and inspiring uses of Bootstrap</span>
+        <span class="tagline">Beautiful and inspiring uses of <a href="http://www.getbootstrap.com">Bootstrap</a></span>
       </div>
     </div>
 


### PR DESCRIPTION
makes sense, no?
Currently, there is no link in the Expo to the main Bootstrap website. 
