### PR TITLE
xml escape the post title

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -19,7 +19,7 @@
     <description>{{ site.description }}</description>
     {% for post in site.posts limit:10 %}
       <item>
-        <title>{{ post.title }}</title>
+        <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
         <link>{{ site.url }}{{ post.url }}</link>


### PR DESCRIPTION
I didn't test this change, just a quick edit because I noted an unescaped ampersand was breaking the RSS-Feed in my browser.

![rss-feed-error](https://cloud.githubusercontent.com/assets/58824/6707520/fe0b82f8-cd67-11e4-9aee-f5cdbfa32898.png)

The offending feed:
```xml
      <item>
        <title>George & Harrison</title>
        <!-- ... -->
      </item>
 ```