### PR TITLE
Jekyll 3.0 and my Photoshop template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 _gh_pages/
 .ruby-version
+.jekyll-metadata

--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,8 @@ future:           false
 name:             Bootstrap Expo
 url:              http://expo.getbootstrap.com
 
+# Plugins
+gems:             [jekyll-paginate]
 
 # Links
 expo_repo:        https://github.com/twbs/bootstrap-expo/

--- a/_data/misc.yml
+++ b/_data/misc.yml
@@ -13,3 +13,7 @@
 - name: Bootstrap 3 for Drupal
   url: https://www.drupal.org/project/bootstrap
   desc: Defacto Drupal theme integration for Bootstrap.
+
+- name: Bootstrap 4 PSD Template
+  url: http://hackerthemes.com/blog/bootstrap-4-psd-template/
+  desc: A PSD grid template to help mockup a Bootstrap project in Adobe Photoshop. Using Bootstrap 4 measurements. 


### PR DESCRIPTION
While adding the Photoshop template I made for Bootstrap 4, I noticed that this site does not build with the latest version of jekyll:

```
Deprecation: You appear to have pagination turned on, but you haven't included the `jekyll-paginate` gem. Ensure you have `gems: [jekyll-paginate]` in your configuration file.
```

I've fixed this issue and added .jekyll-metadata to .gitignore as well. Now it works well with Jekyll 3.0.

The second commit is for adding the template mentioned before.
