### PR TITLE
Add Tophat Themes

### DIFF
--- a/_data/themes.yml
+++ b/_data/themes.yml
@@ -36,7 +36,7 @@
 
 - name: RandThemes
   url: http://randthemes.com
-  desc: WordPress and Bootstrap themes.  
+  desc: WordPress and Bootstrap themes.
 
 - name: PHPstrap.in
   url: http://www.phpstrap.in

--- a/_data/themes.yml
+++ b/_data/themes.yml
@@ -36,7 +36,7 @@
 
 - name: RandThemes
   url: http://randthemes.com
-  desc: WordPress and Bootstrap themes.
+  desc: WordPress and Bootstrap themes.  
 
 - name: PHPstrap.in
   url: http://www.phpstrap.in
@@ -65,3 +65,7 @@
 - name: Bootstrap Zero
   url: http://bootstrapzero.com
   desc: Free starter and custom templates for Bootstrap.
+
+- name: Tophat Themes
+  url: https://themesguide.github.io/top-hat/dist/
+  desc: Stylish, open-source themes for Bootstrap.


### PR DESCRIPTION
I think our Tophat Bootstrap 4 themes would make a nice addition to Resources > themes.

Tophat themes are generated in accordance with http://getbootstrap.com/docs/4.1/getting-started/theming/, and add a lightweight style layer to Bootstrap, similar to the way the [3.x "gradient theme](https://getbootstrap.com/docs/3.3/examples/theme/)" did.

